### PR TITLE
Enabled CORS support

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,3 +1,7 @@
+Header add Access-Control-Allow-Origin "*"
+Header add Access-Control-Allow-Headers "origin, x-requested-with, content-type"
+Header add Access-Control-Allow-Methods "PUT, GET, POST, DELETE, OPTIONS"
+
 RewriteEngine on
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d


### PR DESCRIPTION
It should now be enabled by default.  Apache servers still need to enable the mod_headers module manually.